### PR TITLE
Add command for uninstalling the the app from the device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage/
 doc/
 pkg/
 .yardoc/
+.idea

--- a/lib/simctl/command.rb
+++ b/lib/simctl/command.rb
@@ -3,6 +3,7 @@ require 'simctl/command/create'
 require 'simctl/command/delete'
 require 'simctl/command/erase'
 require 'simctl/command/install'
+require 'simctl/command/uninstall'
 require 'simctl/command/kill'
 require 'simctl/command/launch'
 require 'simctl/command/list'
@@ -21,6 +22,7 @@ module SimCtl
     include SimCtl::Command::Delete
     include SimCtl::Command::Erase
     include SimCtl::Command::Install
+    include SimCtl::Command::Uninstall
     include SimCtl::Command::Kill
     include SimCtl::Command::Launch
     include SimCtl::Command::List

--- a/lib/simctl/command/uninstall.rb
+++ b/lib/simctl/command/uninstall.rb
@@ -1,0 +1,18 @@
+require 'shellwords'
+
+module SimCtl
+  class Command
+    module Uninstall
+      COMMAND = %w[xcrun simctl uninstall]
+
+      # Uninstall an app on a device
+      #
+      # @param device [SimCtl::Device] the device the app should be uninstalled from
+      # @param path Absolute path to the app that should be uninstalled
+      # @return [void]
+      def uninstall_app(device, path)
+        Executor.execute(command_for('uninstall', device.udid, Shellwords.shellescape(path)))
+      end
+    end
+  end
+end

--- a/lib/simctl/command/uninstall.rb
+++ b/lib/simctl/command/uninstall.rb
@@ -1,5 +1,3 @@
-require 'shellwords'
-
 module SimCtl
   class Command
     module Uninstall
@@ -8,10 +6,10 @@ module SimCtl
       # Uninstall an app on a device
       #
       # @param device [SimCtl::Device] the device the app should be uninstalled from
-      # @param path Absolute path to the app that should be uninstalled
+      # @param app_id App identifier of the app that should be uninstalled
       # @return [void]
-      def uninstall_app(device, path)
-        Executor.execute(command_for('uninstall', device.udid, Shellwords.shellescape(path)))
+      def uninstall_app(device, app_id)
+        Executor.execute(command_for('uninstall', device.udid, app_id))
       end
     end
   end

--- a/lib/simctl/device.rb
+++ b/lib/simctl/device.rb
@@ -53,6 +53,14 @@ module SimCtl
       SimCtl.install_app(self, path)
     end
 
+    # Uninstall an app from a device
+    #
+    # @param app_id App identifier of the app that should be uninstalled
+    # @return [void]
+    def uninstall!(app_id)
+      SimCtl.uninstall_app(self, app_id)
+    end
+
     # Kills the device
     #
     # @return [void]

--- a/test/simctl/crud_test.rb
+++ b/test/simctl/crud_test.rb
@@ -82,6 +82,13 @@ class SimCtl::CRUDTest < Minitest::Test
     device.open_url!('https://www.github.com')
   end
 
+  should '0850. uninstall SampleApp' do
+    system 'cd test/SampleApp && xcodebuild -sdk iphonesimulator >/dev/null 2>&1'
+    device = SimCtl.device(udid: udid)
+    device.install!('test/SampleApp/build/Release-iphonesimulator/SampleApp.app')
+    device.uninstall!('com.github.plu.simctl.SampleApp')
+  end
+
   should '0900. kill the device' do
     device = SimCtl.device(udid: udid)
     assert device.kill!


### PR DESCRIPTION
### Context
We need the uninstall command for our acceptance tests. However `simctl` Ruby wrapper doesn't support it. 

### Proposal
I've added the new command and tested it

> Note: I haven't used `minitest` before for testing and I wasn't sure what the numbers in front of the test name are about.