### PR TITLE
Update hardware keyboard

### DIFF
--- a/lib/simctl/device_settings.rb
+++ b/lib/simctl/device_settings.rb
@@ -29,6 +29,16 @@ module SimCtl
       end
     end
 
+    # Updates hardware keyboard settings
+    #
+    # @param enabled value to replace
+    # @return [vod]
+    def update_hardware_keyboard!(enabled)
+      edit_plist(path.preferences_plist) do |plist|
+        plist['AutomaticMinimizationEnabled'] = enabled
+      end
+    end
+
     def edit_plist(path, &block)
       plist = File.exists?(path) ? CFPropertyList::List.new(file: path) : CFPropertyList::List.new
       content = CFPropertyList.native_types(plist.value) || {}

--- a/test/simctl/crud_test.rb
+++ b/test/simctl/crud_test.rb
@@ -113,6 +113,12 @@ class SimCtl::CRUDTest < Minitest::Test
     assert File.exists?(device.path.preferences_plist)
   end
 
+  should '1300. update hardware keyboard' do
+    device = SimCtl.device(udid: udid)
+    device.settings.update_hardware_keyboard!(false)
+    assert File.exists?(device.path.preferences_plist)
+  end
+
   should '9800. reset the device' do
     old_device = SimCtl.device(udid: udid)
     new_device = old_device.reset!


### PR DESCRIPTION
Since Xcode 6, the iOS simulator has an option to "Connect Hardware Keyboard". This is enabled by default and will cause the keyboard to not appear as soon as you use the keyboard on your mac to input on the simulator until to toggle the feature.

![screen shot 2016-11-23 at 14 28 26](https://cloud.githubusercontent.com/assets/346590/20592742/81b715c4-b22f-11e6-9b16-b679df07635f.png)

This leads to inconsistency on our snapshot tests on CI, as we can't predict the state of this feature, so it's safer to seed the value before launching the simulator.

The details about the solution can be found in https://github.com/calabash/run_loop/pull/57 