### PR TITLE
Update rake and coveralls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,28 +9,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.3.4)
-    coveralls (0.8.10)
-      json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.11.0)
+    coveralls (0.8.17)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.12.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
-      tins (~> 1.6.0)
+      tins (~> 1.6)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.25)
-      unf (>= 0.0.5, < 1.0.0)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
-    json (1.8.3)
-    mime-types (2.99)
+    json (2.0.2)
     naturally (2.1.0)
-    netrc (0.11.0)
     rake (10.4.2)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -44,18 +33,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    simplecov (0.11.1)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    term-ansicolor (1.3.2)
+    term-ansicolor (1.4.0)
       tins (~> 1.0)
-    thor (0.19.1)
-    tins (1.6.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.1)
+    thor (0.19.4)
+    tins (1.13.0)
 
 PLATFORMS
   ruby
@@ -67,4 +53,4 @@ DEPENDENCIES
   simctl!
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     docile (1.1.5)
     json (2.0.2)
     naturally (2.1.0)
-    rake (10.4.2)
+    rake (12.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)


### PR DESCRIPTION
I ran into an issue when trying bundle install with ruby `2.4.0` and bundler `1.13.7`. It failed to build the `json` native extension.

I updated the `coveralls` gem and the issue disappeared. While I was at it, I also updated `rake`.