### PR TITLE
Check simulator runtime version instead of Xcode version

### DIFF
--- a/lib/simctl/device.rb
+++ b/lib/simctl/device.rb
@@ -240,7 +240,7 @@ module SimCtl
           ]
         end
       when :ios
-        if Xcode::Version.gte? '8.0'
+        if runtime.gte? '9.0'
           [
             'com.apple.SimulatorBridge',
             'com.apple.SpringBoard',
@@ -252,6 +252,7 @@ module SimCtl
           [
             'com.apple.SimulatorBridge',
             'com.apple.SpringBoard',
+            'com.apple.backboardd',
             'com.apple.mobile.installd',
           ]
         end

--- a/lib/simctl/runtime.rb
+++ b/lib/simctl/runtime.rb
@@ -15,6 +15,12 @@ module SimCtl
       other.identifier == identifier
     end
 
+    def gte?(other_version)
+      return false if other_version.nil?
+      return false unless other_version.kind_of? String
+      Gem::Version.new(version) >= Gem::Version.new(other_version)
+    end
+
     # Returns the latest available runtime
     #
     # @param name [String] type (ios, watchos, tvos)

--- a/spec/simctl/warmup_spec.rb
+++ b/spec/simctl/warmup_spec.rb
@@ -2,19 +2,39 @@ require 'spec_helper'
 
 RSpec.describe SimCtl do
   describe '#warmup' do
-    if SimCtl.device_set_path.nil?
-      it 'warms up and returns a device for given strings' do
-        expect(SimCtl.warmup('iPhone 6', 'iOS 9.3')).to be_kind_of SimCtl::Device
-      end
+    context 'when simulator version is >= 9.0' do
+      if SimCtl.device_set_path.nil?
+        it 'warms up and returns a device for given strings' do
+          expect(SimCtl.warmup('iPhone 6', 'iOS 9.3')).to be_kind_of SimCtl::Device
+        end
 
-      it 'warms up and returns a device for given objects' do
-        devicetype = SimCtl.devicetype(name: 'iPhone 5')
-        runtime = SimCtl::Runtime.latest(:ios)
-        expect(SimCtl.warmup(devicetype, runtime)).to be_kind_of SimCtl::Device
+        it 'warms up and returns a device for given objects' do
+          devicetype = SimCtl.devicetype(name: 'iPhone 5')
+          runtime = SimCtl::Runtime.latest(:ios)
+          expect(SimCtl.warmup(devicetype, runtime)).to be_kind_of SimCtl::Device
+        end
+      else
+        it 'raises exception' do
+          expect { SimCtl.warmup('iPhone 6', 'iOS 9.3') }.to raise_error SimCtl::DeviceNotFound
+        end
       end
-    else
-      it 'raises exception' do
-        expect { SimCtl.warmup('iPhone 6', 'iOS 9.3') }.to raise_error SimCtl::DeviceNotFound
+    end
+
+    context 'when simulator version is < 9.0' do
+      if SimCtl.device_set_path.nil?
+        it 'warms up and returns a device for given strings' do
+          expect(SimCtl.warmup('iPhone 5', 'iOS 8.4')).to be_kind_of SimCtl::Device
+        end
+
+        it 'warms up and returns a device for given objects' do
+          devicetype = SimCtl.devicetype(name: 'iPhone 5')
+          runtime = SimCtl.runtime(name: 'iOS 8.4')
+          expect(SimCtl.warmup(devicetype, runtime)).to be_kind_of SimCtl::Device
+        end
+      else
+        it 'raises exception' do
+          expect { SimCtl.warmup('iPhone 6', 'iOS 9.3') }.to raise_error SimCtl::DeviceNotFound
+        end
       end
     end
   end

--- a/spec/simctl/warmup_spec.rb
+++ b/spec/simctl/warmup_spec.rb
@@ -2,40 +2,33 @@ require 'spec_helper'
 
 RSpec.describe SimCtl do
   describe '#warmup' do
-    context 'when simulator version is >= 9.0' do
+    RSpec.shared_examples 'warmup examples' do |parameters|
+      let (:device_name) { parameters[:device] }
+      let (:runtime_name) { parameters[:runtime] }
+
       if SimCtl.device_set_path.nil?
         it 'warms up and returns a device for given strings' do
-          expect(SimCtl.warmup('iPhone 6', 'iOS 9.3')).to be_kind_of SimCtl::Device
+          expect(SimCtl.warmup(device_name, runtime_name)).to be_kind_of SimCtl::Device
         end
 
         it 'warms up and returns a device for given objects' do
-          devicetype = SimCtl.devicetype(name: 'iPhone 5')
-          runtime = SimCtl::Runtime.latest(:ios)
+          devicetype = SimCtl.devicetype(name: device_name)
+          runtime = SimCtl.runtime(name: runtime_name)
           expect(SimCtl.warmup(devicetype, runtime)).to be_kind_of SimCtl::Device
         end
       else
         it 'raises exception' do
-          expect { SimCtl.warmup('iPhone 6', 'iOS 9.3') }.to raise_error SimCtl::DeviceNotFound
+          expect { SimCtl.warmup(device_name, runtime_name) }.to raise_error SimCtl::DeviceNotFound
         end
       end
     end
 
-    context 'when simulator version is < 9.0' do
-      if SimCtl.device_set_path.nil?
-        it 'warms up and returns a device for given strings' do
-          expect(SimCtl.warmup('iPhone 5', 'iOS 8.4')).to be_kind_of SimCtl::Device
-        end
+    context 'when simulator version is >= 9.0' do
+      include_examples 'warmup examples', {device: 'iPhone 6', runtime: 'iOS 9.3'}
+    end
 
-        it 'warms up and returns a device for given objects' do
-          devicetype = SimCtl.devicetype(name: 'iPhone 5')
-          runtime = SimCtl.runtime(name: 'iOS 8.4')
-          expect(SimCtl.warmup(devicetype, runtime)).to be_kind_of SimCtl::Device
-        end
-      else
-        it 'raises exception' do
-          expect { SimCtl.warmup('iPhone 6', 'iOS 9.3') }.to raise_error SimCtl::DeviceNotFound
-        end
-      end
+    context 'when simulator version is < 9.0' do
+      include_examples 'warmup examples', {device: 'iPhone 5', runtime: 'iOS 8.4'}
     end
   end
 end


### PR DESCRIPTION
It turns out that when using Xcode 8.2 and a simulator running iOS 8, the `com.apple.medialibraryd` service isn't required for the device to be considered ready.

For iOS simulators, I replaced the Xcode check with a runtime check.

Let's see what the CI says...