### PR TITLE
Fix Device#ready? on Xcode 9

### DIFF
--- a/lib/simctl/device.rb
+++ b/lib/simctl/device.rb
@@ -121,7 +121,6 @@ module SimCtl
     #
     # @return [Bool]
     def ready?
-      # TODO: Should look for different services depending on device type (iphone/ipad, tv, watch)
       running_services = launchctl.list.reject {|service| service.pid.to_i == 0 }.map {|service| service.name}
       (required_services_for_ready - running_services).empty?
     end
@@ -249,12 +248,18 @@ module SimCtl
           ]
         end
       when :ios
-        if Xcode::Version.gte? '8.0'
+        if Xcode::Version.gte? '9.0'
+          [
+            'com.apple.backboardd',
+            'com.apple.mobile.installd',
+            'com.apple.CoreSimulator.bridge',
+            'com.apple.SpringBoard',
+          ]
+        elsif Xcode::Version.gte? '8.0'
           [
             'com.apple.SimulatorBridge',
             'com.apple.SpringBoard',
             'com.apple.backboardd',
-            'com.apple.medialibraryd',
             'com.apple.mobile.installd',
           ]
         else

--- a/lib/simctl/device_path.rb
+++ b/lib/simctl/device_path.rb
@@ -17,7 +17,11 @@ module SimCtl
     end
 
     def launchctl
-      @launchctl ||= File.join(runtime_root, 'bin/launchctl')
+      @launchctl ||= if Xcode::Version.gte? '9.0'
+                       "#{Xcode::Path.home}//Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/bin/launchctl"
+                     else
+                        File.join(runtime_root, 'bin/launchctl')
+                     end
     end
 
     def preferences_plist


### PR DESCRIPTION
Hey Plu 👋, launchctl changed location on Xcode 9. This PR basically follows: https://github.com/facebook/FBSimulatorControl/pull/303 except that it doesn't use `CoreSimulator.SimDevice` information, but the path is still hardcoded.

I also updated the required list of services to be the same as [`- [FBSimulatorBootVerificationStrategy requiredLaunchdServicesToVerifyBooted]`](https://github.com/facebook/FBSimulatorControl/blob/344a151f6ce3100c7dd7513d14cfcf7bedc03fa6/FBSimulatorControl/Strategies/FBSimulatorBootVerificationStrategy.m#L81-L115)