### PR TITLE
Small fixes for robustness

### DIFF
--- a/lib/simctl/xcode/path.rb
+++ b/lib/simctl/xcode/path.rb
@@ -11,6 +11,14 @@ module SimCtl
         def sdk_root
           File.join(HOME, 'Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk')
         end
+
+        def runtime_profiles
+          if Xcode::Version.gte? '9.0'
+            File.join(HOME, 'Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/')
+          else
+            File.join(HOME, 'Platforms/iPhoneSimulator.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
I've forked simctl to support my team's Xcode 9 deployment.

I'd like to contribute what I believe it a more meaningful patch for determining the runtime root path location and some robustness on not relying on the `.simruntime`'s directory name to determine version identifiers.

---

```
Various behavioral changes

- Determine runtime version by reading `Contents/Info.plist`, instead of the
  directory name.
- Change behavior to search each Xcodes' included runtime profiles first when
  locating the runtime root path.
- Add renamed Xcode 9 runtime profile paths.
```

