### PR TITLE
Lazy load xcode-select and xcodebuild

### DIFF
--- a/lib/simctl/xcode/path.rb
+++ b/lib/simctl/xcode/path.rb
@@ -1,7 +1,6 @@
 module SimCtl
   module Xcode
     class Path
-
       class << self
         def home
           @home ||= `xcode-select -p`.chomp

--- a/lib/simctl/xcode/path.rb
+++ b/lib/simctl/xcode/path.rb
@@ -4,7 +4,7 @@ module SimCtl
 
       class << self
         def home
-          `xcode-select -p`.chomp
+          @home ||= `xcode-select -p`.chomp
         end
 
         def sdk_root

--- a/lib/simctl/xcode/path.rb
+++ b/lib/simctl/xcode/path.rb
@@ -1,22 +1,21 @@
 module SimCtl
   module Xcode
     class Path
-      HOME = `xcode-select -p`.chomp
 
       class << self
         def home
-          HOME
+          `xcode-select -p`.chomp
         end
 
         def sdk_root
-          File.join(HOME, 'Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk')
+          File.join(home, 'Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk')
         end
 
         def runtime_profiles
           if Xcode::Version.gte? '9.0'
-            File.join(HOME, 'Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/')
+            File.join(home, 'Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/')
           else
-            File.join(HOME, 'Platforms/iPhoneSimulator.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/')
+            File.join(home, 'Platforms/iPhoneSimulator.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/')
           end
         end
       end

--- a/lib/simctl/xcode/version.rb
+++ b/lib/simctl/xcode/version.rb
@@ -1,12 +1,11 @@
 module SimCtl
   module Xcode
     class Version
-
       class << self
         def gte?(version)
-          thing = Gem::Version.new(`xcodebuild -version`.scan(/Xcode (\S+)/).flatten.first)
+          @version ||= Gem::Version.new(`xcodebuild -version`.scan(/Xcode (\S+)/).flatten.first)
 
-          thing >= Gem::Version.new(version)
+          @version >= Gem::Version.new(version)
         end
       end
     end

--- a/lib/simctl/xcode/version.rb
+++ b/lib/simctl/xcode/version.rb
@@ -1,11 +1,12 @@
 module SimCtl
   module Xcode
     class Version
-      VERSION = Gem::Version.new(`xcodebuild -version`.scan(/Xcode (\S+)/).flatten.first)
 
       class << self
         def gte?(version)
-          VERSION >= Gem::Version.new(version)
+          thing = Gem::Version.new(`xcodebuild -version`.scan(/Xcode (\S+)/).flatten.first)
+
+          thing >= Gem::Version.new(version)
         end
       end
     end


### PR DESCRIPTION
## Motivation
We recently add `simctl` to fastlane (thank you for this awesome gem 😊) in this PR - https://github.com/fastlane/fastlane/pull/12039. However, we had to do some weird things to make our rubocop setup happy when including this gem on different operating systems. The initial execution of finding `xcode-select` and `xcodebuild` on gem/file load causes weird things when running on a non-macOS.

My proposed change lazy loads the finding of `xcode-select` and  `xcodebuild` to prevent issues of when this gem is included in things that aren't always running on macOS. 💪 

Let me know if there is anything else you would like added to this PR or if you have any questions regarding my thoughts/issues ❤️ 