### PR TITLE
Device locale can now be set

### DIFF
--- a/lib/simctl/device_settings.rb
+++ b/lib/simctl/device_settings.rb
@@ -57,5 +57,14 @@ module SimCtl
         plist[key].unshift(language).uniq!
       end
     end
+
+    # Sets the device locale
+    #
+    # @return [void]
+    def set_locale(locale)
+      edit_plist(path.global_preferences_plist) do |plist|
+        plist['AppleLocale'] = locale
+      end
+    end
   end
 end

--- a/spec/simctl/device_interaction_spec.rb
+++ b/spec/simctl/device_interaction_spec.rb
@@ -1,3 +1,4 @@
+require 'cfpropertylist'
 require 'securerandom'
 require 'spec_helper'
 
@@ -94,6 +95,18 @@ RSpec.describe SimCtl, order: :defined do
     describe 'setting the device language' do
       it 'sets the device language' do
         @device.settings.set_language('de')
+        plist = CFPropertyList::List.new(file: @device.path.global_preferences_plist)
+        content = CFPropertyList.native_types(plist.value)
+        expect(content['AppleLanguages']).to include('de')
+      end
+    end
+
+    describe 'setting the device locale' do
+      it 'sets the device locale' do
+        @device.settings.set_locale('en_DE')
+        plist = CFPropertyList::List.new(file: @device.path.global_preferences_plist)
+        content = CFPropertyList.native_types(plist.value)
+        expect(content['AppleLocale']).to be == 'en_DE'
       end
     end
   end


### PR DESCRIPTION
The test for `set_language` was changed to follow the new `set_locale` test. They assert that the side-effect happened to the plist file, which I'm not sure it's according to the rest of the tests, but checking quickly it doesn't look to be a problem. If the old test was preferred please let me know and I switch change back to that.