### PR TITLE
Use boot instead of launch

### DIFF
--- a/fastlane-plugin-simctl/lib/fastlane/plugin/simctl/helper/simctl_helper.rb
+++ b/fastlane-plugin-simctl/lib/fastlane/plugin/simctl/helper/simctl_helper.rb
@@ -3,7 +3,7 @@ module Fastlane
     class SimctlHelper
       def self.execute_with_simulator_ready(action, block, runtime, type, name)
         device = create_device(runtime, type, name)
-        device.launch
+        device.boot
         device.wait(90) do |d|
           Fastlane::UI.message("Waiting for simulator `#{d.name}` to be ready")
           d.state == :booted && d.ready?


### PR DESCRIPTION
The Fastlane plugin wasn't launching the simulator if it was already running from another job. Switching the command to boot fixed it. To test this, just run the simulator manually then start a Fastlane build. 