### PR TITLE
Turn off sliding hint on keyboard

### DIFF
--- a/lib/simctl/device_settings.rb
+++ b/lib/simctl/device_settings.rb
@@ -13,6 +13,7 @@ module SimCtl
     # @return [void]
     def disable_keyboard_helpers
       edit_plist(path.preferences_plist) do |plist|
+        plist['DidShowContinuousPathIntroduction'] = true
         %w[
           KeyboardAllowPaddle
           KeyboardAssistant


### PR DESCRIPTION
Just get rid of that in `disable_keyboard_helpers`:

![image](https://user-images.githubusercontent.com/39100/71014226-e2a6a280-20f1-11ea-952a-96d730d64abf.png)
