### PR TITLE
Support Ruby 3.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     simctl (1.6.10)
       CFPropertyList
       naturally
+      ostruct
 
 GEM
   remote: https://rubygems.org/
@@ -24,6 +25,7 @@ GEM
       reline (>= 0.3.0)
     json (2.6.3)
     naturally (2.2.1)
+    ostruct (0.6.3)
     parallel (1.22.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
@@ -71,6 +73,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   coveralls

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.6)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
     ast (2.4.2)
+    base64 (0.3.0)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -25,6 +28,7 @@ GEM
       reline (>= 0.3.0)
     json (2.6.3)
     naturally (2.2.1)
+    nkf (0.2.0)
     ostruct (0.6.3)
     parallel (1.22.1)
     parser (2.7.2.0)
@@ -35,7 +39,7 @@ GEM
     rake (13.0.6)
     reline (0.3.2)
       io-console (~> 0.5)
-    rexml (3.2.5)
+    rexml (3.4.4)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)

--- a/simctl.gemspec
+++ b/simctl.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'CFPropertyList'
   s.add_dependency 'naturally'
+  s.add_dependency 'ostruct'
 end


### PR DESCRIPTION
## Context

couldn't use with Ruby 3.4 and 3.5

<details>
<summary> error logs </summary>

```shell
require 'simctl'
/Users/mataku/src/github.com/plu/simctl/lib/simctl/command/keychain.rb:1:in 'Kernel#require': cannot load such file -- ostruct (LoadError)
```

```shell
require 'simctl'
/Users/mataku/.rbenv/versions/3.5-dev/lib/ruby/gems/3.5.0+0/gems/CFPropertyList-3.0.6/lib/cfpropertylist/rbCFPropertyList.rb:3:in 'Kernel#require': cannot load such file -- kconv (LoadError)
```

</details>

## Changes

- bundle update CFPropertyList to use 3.0.7 for Ruby 3.4
- Add ostruct as dependency explicitly. bundled gem in Ruby 3.5